### PR TITLE
Fix one time password being used more than once

### DIFF
--- a/lib/magic_auth.ex
+++ b/lib/magic_auth.ex
@@ -145,7 +145,8 @@ defmodule MagicAuth do
         {:error, :code_expired}
 
       Bcrypt.verify_pass(password, one_time_password.hashed_password) ->
-        {:ok, one_time_password}
+        deleted_one_time_password = MagicAuth.Config.repo_module().delete!(one_time_password)
+        {:ok, deleted_one_time_password}
 
       true ->
         {:error, :invalid_code}


### PR DESCRIPTION
Awesome library! I really enjoyed exploring the code—it's well-structured and easy to follow!

I was messing around with it and saw that I could reuse passwords codes.

To test this:

1. Go through sign up flow for `test@test.com`
2. Enter code
3. Everything works
4. Open inspector and clear cookies
5. Navigate to `/sessions/password?email=test@test.com`
6. Re-enter same code
7. Gain access

This is important to protect against to protect people from password replay attacks. These one time codes can easy be captured by phishing sites, remote access trojans, and keylogger malware. 

This PR deletes the email's password once it's verified, ensuring it can only be used for verification once. While I think there might be more efficient ways to implement this, I wanted to open up the conversation. One option could be using a multi or splitting this logic into a separate function to be used during login flow. Personally, I lean towards the multi approach, as it would eliminate the small window of time where the password is still reusable after it's been validated. I’d love to hear your thoughts before I spend more time refactoring it into a multi process.